### PR TITLE
Speed up `security_audit` job and let it find all RUSTSEC advisories

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -8,9 +8,13 @@ on:
     paths:
     - '**/Cargo.toml'
     - '**/Cargo.lock'
+    - '.github/workflows/audit.yml'
   push:
     branches:
     - main
+    - 'run-ci/**'
+    - '**/run-ci/**'
+  workflow_dispatch:
 
 env:
   RUST_BACKTRACE: 1

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -47,7 +47,7 @@ jobs:
         # but it works for the very simple call in actions-rs/audit-check, which is what matters.
         case "$1" in
         generate-lockfile)
-          printf '::warning SKIPPING: %s %s\n' "$0" "$*" ;;
+          printf '::warning:: SKIPPING: %s %s\n' "$0" "$*" ;;
         *)
           exec "$0.orig" "$@" ;;
         esac

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -32,6 +32,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-audit
     - uses: actions-rs/audit-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -35,6 +35,25 @@ jobs:
     - uses: taiki-e/install-action@v2
       with:
         tool: cargo-audit
+    - name: Stub out `cargo generate-lockfile` to work around actions-rs/audit-check#163
+      run: |
+        cd ~/.cargo/bin
+        mv cargo cargo.orig
+
+        cat >cargo <<'EOF'
+        #!/bin/sh
+        set -eu
+        # Assume the first argument is the subcommand, rather than an option. This is not robust,
+        # but it works for the very simple call in actions-rs/audit-check, which is what matters.
+        case "$1" in
+        generate-lockfile)
+          printf '::warning SKIPPING: %s %s\n' "$0" "$*" ;;
+        *)
+          exec "$0.orig" "$@" ;;
+        esac
+        EOF
+
+        chmod +x cargo
     - uses: actions-rs/audit-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust-next.yml
+++ b/.github/workflows/rust-next.yml
@@ -6,6 +6,7 @@ permissions:
 on:
   schedule:
   - cron: '1 1 1 * *'
+  workflow_dispatch:
 
 env:
   RUST_BACKTRACE: 1


### PR DESCRIPTION
Fixes #46

#### Changes

1. Make workflows trigger in slightly more circumstances, building on 74e3475 ([#43](https://github.com/Byron/cargo-smart-release/pull/43)) to make workflows easier to run and test.

   Of particular note is that this makes it so changes to the workflow that defines the `security_audit` job trigger the audit. After all, this PR doesn't actually modify `Cargo.toml` or `Cargo.lock`. So if not for that, the workflow would not have run on this PR!

2. Decrease the time it takes the `security_audit` job to run, from about 2 minutes to about 10 seconds, by presintalling a `cargo-audit` binary rather than building it from source each time.

3. In `security_audit`, stub out `cargo generate-lockfile` to work around a bug where `Cargo.lock` is regenerated every time even when it is fully usable ([actions-rs/audit-check#163](https://github.com/actions-rs/audit-check/issues/163)).

   **That bug was the cause of [#46](https://github.com/Byron/cargo-smart-release/issues/46).** Vulnerable dependencies in `Cargo.lock` should be reported, but weren't reported for advisories on transitive dependencies that a SemVer-compatible upgrade could fix.

   As noted in 3f243c1, a better long-term solution may be to stop using the `actions-rs/audit-check` action, since it is unmaintained, so that and other bugs are unlikely to be resolved in it. But until then it seems to me that this approach is reasonable.

It is intentional that the `security_audit` job fails on this PR, since vulnerable dependencies are--even more than before--discovered. (The reason it does not fail on PRs like #47 is that they don't make changes to any files that are expected to affect the results of either of the jobs in the `audit` workflow, so that workflow is not run at all on them.)

#### An oddity

I have noticed that the added check created dynamically by `actions-rs/audit-check` that shows the advisories in readable form is sometimes attached to the result of a *different* workflow that is also run on the same `push` event: either the main CI workflow, or a CodeQL workflow (I have CodeQL enabled in my fork for experimental GitHub Actions scanning).

I think this is not too big of a problem. I am not sure if this was always happening and I only noticed it when testing various approaches, or if it is new. If it is new, then my guess is that making the `security_audit` job complete much faster is a contributing factor, since this allows the check to be available when other operations run that work with checks.

I don't know if this ever happens on the `pull_request` trigger. It cannot be tested for that trigger on a pull request from a fork, due to limitations in the GitHub check API--or in the way the `cargo-rs/audit-check` action uses it, if the limitations have been alleviated since then, I am not sure. (These days, the typical way for an action to report something on a PR in a more salient way than just outputting it would be for it to post a review comment.)

Anyway, that's why the report is in the GitHub Actions output here rather than in a separate created check. (This is not new; that's how it worked before, too.)

#### Outscoped

The fix in (3) casues the vulnerable version (described in #46) of the `crossbeam-channel` dependency in `Cargo.lock` to be [reported](https://github.com/Byron/cargo-smart-release/actions/runs/14511068817/job/40709675616?pr=48#step:5:27). However, I have not updated that dependency in this PR. Likewise, I have not enabled monthly grouped Dependabot version updates for Rust dependencies, though it may make sense to do so.

**I recommend enabling** Dependabot security updates in this repository. This is separate from version updates and it can only be enabled in the repository's [security settings](https://github.com/Byron/cargo-smart-release/settings/security_analysis) (though its operation can be affected in some ways by `dependabot.yml`). This should automatically, and almost immediately, offer an update for `crossbeam-channel`.

Since I don't have access to those settings, I am assuming Dependabot security updates are not enabled based on no such PR being opened already for `crossbeam-channel`. The changes here are independent of the operation of Dependabot. Working around https://github.com/actions-rs/audit-check/issues/163 is valuable so make it so CI results are complete, but this would not have been keeping Dependabot security updates from working.