### PR TITLE
Update project URL and add security policy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-smart-release"
 version = "0.21.6"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-repository = "https://github.com/Byron/cargo-smart-release"
+repository = "https://github.com/GitoxideLabs/cargo-smart-release"
 description = "Cargo subcommand for fearlessly releasing crates in workspaces."
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please feel free to [draft a GitHub advisory](https://github.com/GitoxideLabs/cargo-smart-release/security/advisories/new), and I will work with you to disclose and or resolve the issue responsibly.
+
+If this doesn't seem like the right approach or there are questions, please feel free to reach out to the email used in Sebastian Thiel's commits.
+
+Thank you.


### PR DESCRIPTION
This makes two changes:

- Update the URL in `Cargo.toml` to point to `GitoxideLabs/cargo-smart-release` since the repo was moved (though the old URL will still work as a redirect).
- Add a `SECURITY.md` file with the same wording as in `gitoxide`, but where the hyperlink is for drafting a `cargo-smart-release` advisory (rather than a `gitoxide` advisory).

I recently enabled the GitHub private vulnerability reporting feature for this repository. Thus, the instructions in the security policy this introduces can be followed. Since it is based on the `gitoxide` security policy, my guess is that it is okay. Nonetheless, it makes a claim explicitly on your behalf ("I will work with you to..."). So I still don't want to merge it myself without your review.

(The security audit check fails for the usual standing reason that we depend on an old `gix-features` through `gix-testtools`--but only as a dev dependency, since #51. It is triggered here for the `pull_request` event because this changes `Cargo.toml`, even though the change there does not affect dependencies, their versions, or how they are used.)

---

This is a draft while I investigate [an unexpected failure](https://github.com/GitoxideLabs/cargo-smart-release/actions/runs/14555552845/job/40832067274?pr=55#step:2:387) in the Windows installation test.

*Edit:* The failure is due to https://github.com/vorner/signal-hook/issues/173 and analogous to https://github.com/GitoxideLabs/gitoxide/issues/1959. It is not related to this PR. The installation test intentionally installs from crates.io and probably shouldn't run on the `push` or `pull_request` triggers at all; see #56. I don't think that needs to block this.