### PR TITLE
Improve event triggers for crates.io install test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: none
     name: CI
-    needs: [test, docs, rustfmt, clippy, installation]
+    needs: [test, docs, rustfmt, clippy]
     runs-on: ubuntu-latest
     steps:
     - name: Done
@@ -50,18 +50,6 @@ jobs:
     - name: Journey
       if: ${{ matrix.os != 'windows-latest' }} # on windows, journey tests don't run yet and it's not important enough right now
       run: just ci-test
-
-  installation:
-    name: Installation
-    strategy:
-      matrix:
-        os: ["ubuntu-latest", "windows-latest"]
-        rust: ["stable"]
-    continue-on-error: ${{ matrix.rust != 'stable' }}
-    runs-on: ${{ matrix.os }}
-    steps:
-    - name: "Installation from crates.io: cargo-smart-release"
-      run: cargo install --debug --force cargo-smart-release
 
   lockfile:
     runs-on: ubuntu-latest

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,0 +1,30 @@
+name: Installation
+
+permissions:
+  contents: read
+
+on:
+  push:
+    tags:
+    - 'v*'
+  schedule:
+  - cron: '1 1 1 * *'
+  workflow_dispatch:
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+  CLICOLOR: 1
+
+jobs:
+  installation:
+    name: Installation
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "windows-latest"]
+        rust: ["stable"]
+    continue-on-error: ${{ matrix.rust != 'stable' }}
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: "Installation from crates.io: cargo-smart-release"
+      run: cargo install --debug --force cargo-smart-release

--- a/.github/workflows/rust-next.yml
+++ b/.github/workflows/rust-next.yml
@@ -51,7 +51,7 @@ jobs:
       with:
         toolchain: stable
     - uses: Swatinem/rust-cache@v2
-    - name: Update dependencues
+    - name: Update dependencies
       run: cargo update
     - name: Default features
       run: cargo test --workspace --all-targets


### PR DESCRIPTION
Fixes #56

This moves the `installation` test, which tests if installation works from crates.io, out of the main `ci.yml` workflow and to a new workflow `install.yml` that runs after a new release is made (rather than when commits are pushed or pull requests are opened or updated), as well as once a week and if it is manually triggered.

Multiple events occur in connection with a release. This includes the creation and publication of the GitHub release. The could trigger on an explicitly release-related event, but it instead triggers on the `push` event, for tags only, where the tag starts with `v`. All these events take place after the crate has been uploaded to crates.io for the release, so installation should succeed.

The reason for running when the version tag is pushed is that, since `cargo-smart-release` publishes itself, and it creates and pushes the version tag before it creates the GitHub release, this will allow it to begin running sooner and thus catch and notify developers of any installation problems a bit earlier:

https://github.com/GitoxideLabs/cargo-smart-release/blob/d59c889b5cd931ac22c27e02ef2af063834f6b11/src/command/release/mod.rs#L445-L456

But it would also be fine to trigger on a GitHub-release related event, and it could be changed to that if the need arises.

For scheduled runs, this runs once a week and is triggered on the same day and at the same time as the `rust-next.yml` workflow. This is so that their result can be compared, mainly with the idea that if `rust-next.yml` fails unexpectedly, the `install.yml` run may help indicate whether recent unpublished changes in `cargo-smart-release` are plausibly the cause.