### PR TITLE
Always let Dependabot propose `Cargo.lock` updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,12 @@ updates:
   directory: '/'
   schedule:
     interval: monthly
+  allow:
+  - dependency-type: all
   groups:
     cargo:
       patterns: ['*']
+
 - package-ecosystem: github-actions
   directory: '/'
   schedule:


### PR DESCRIPTION
This fixes a bug in the `dependabot.yml` configuration since #52, where we intend Dependabot to include the effect of `cargo update`, but this does not happen because `dependency-type: all` was not explicitly allowed.

This does not make an analogous change to the Dependabot configuration for GitHub Actions, because `all` and `direct` currently have the same effect for them (and it is not obvious how it would work if that ever changes, or which we would prefer).

For details on why this is needed for Dependabot to update most locked dependencies in `Cargo.lock` aside from the case where the update is done as part of updating a `Cargo.toml` dependency, see:

- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated#allowing-specific-dependencies-to-be-updated
- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#dependency-type-allow

---

The corresponding PR in `gitoxide` (where https://github.com/GitoxideLabs/gitoxide/pull/1948 had the same bug as #52) is https://github.com/GitoxideLabs/gitoxide/pull/1967. The description there contains some information applicable both there and here. The fork-internal Dependabot test PR used to validate this was https://github.com/EliahKagan/cargo-smart-release/pull/8.

The Dependabot PR that will be created due to this changed configuration will include an attempt to upgrade `pulldown-cmark`. Per #54, that will not currently work. Unless work on that is to proceed soon, it may make sense to have Dependabot automatically ignore non-patch updates to `pulldown-cmark`. I might make that change separately, but I haven't attempted to include such a thing here; instead, this PR is only for fixing a specific bug in the configuration I added in #52.