### PR TITLE
Refine Dependabot config for breaking changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   directory: '/'
   schedule:
     interval: monthly
+  commit-message:
+    prefix: ''
   allow:
   - dependency-type: all
   groups:
@@ -14,6 +16,8 @@ updates:
   directory: '/'
   schedule:
     interval: monthly
+  commit-message:
+    prefix: ''
   groups:
     github-actions:
       patterns: ['*']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,12 @@ updates:
     prefix: ''
   allow:
   - dependency-type: all
+  ignore:
+  # Temporarily keep pulldown-cmark at 0.9.* (see comments in #54 and #59).
+  - dependency-name: pulldown-cmark
+    update-types:
+    - 'version-update:semver-major'
+    - 'version-update:semver-minor'
   groups:
     cargo:
       patterns: ['*']


### PR DESCRIPTION
This makes two changes to the Dependabot configuration, of which the second is the most significant:

- Omit conventional prefix in Dependabot commits (d71b7b7e30cd6659c5a762f0d9d4bbfeb6de1d0b)
- Get only patch version updates to `pulldown-cmark` (aeb91ee22bcd8aadd64a3261e3de2ed985c99485)

See the commit messages for details.

One important intended effect of the second change (aeb91ee22bcd8aadd64a3261e3de2ed985c99485) is that the only breaking changes in the Dependabot version update that is created after this PR is merged will be changes in `gix`.

See https://github.com/EliahKagan/cargo-smart-release/pull/14 for what that forthcoming Dependabot PR will look like. Specifically, the first commit resembles what Dependabot will do, and the second commit resembles the changes I will propose in the Dependabot PR to adapt code in `cargo-smart-release` to the new version of `gix`. (Specifically, I'll cherry-pick that second commit into the forthcoming Dependabot PR, assuming the first commit is as similar as I expect.)

We can eventually undo aeb91ee22bcd8aadd64a3261e3de2ed985c99485 when work on adapting the code to changes in `pulldown-cmark` resumes.