### PR TITLE
Thanks clippy

### DIFF
--- a/src/changelog/parse.rs
+++ b/src/changelog/parse.rs
@@ -427,7 +427,7 @@ fn record_unknown_range(out: &mut Vec<section::Segment>, range: Option<Range<usi
 }
 
 fn track_unknown_event(unknown_event: Event<'_>, unknown: &mut String) {
-    log::trace!("Cannot handle {:?}", unknown_event);
+    log::trace!("Cannot handle {unknown_event:?}");
     match unknown_event {
         Event::Html(text)
         | Event::Code(text)

--- a/src/command/changelog.rs
+++ b/src/command/changelog.rs
@@ -129,7 +129,7 @@ pub fn changelog(opts: Options, crates: Vec<String>) -> anyhow::Result<()> {
         change.commit()?;
     }
     if num_changes != 0 {
-        log::info!("Wrote {} changelogs", num_changes);
+        log::info!("Wrote {num_changes} changelogs");
     }
 
     Ok(())

--- a/src/command/release/cargo.rs
+++ b/src/command/release/cargo.rs
@@ -56,9 +56,7 @@ pub(in crate::command::release_impl) fn publish_crate(
             bail!("Could not successfully execute 'cargo publish'.")
         } else {
             log::warn!(
-                "'cargo publish' run {} failed but we retry up to {} times to rule out flakiness",
-                attempt,
-                max_attempts
+                "'cargo publish' run {attempt} failed but we retry up to {max_attempts} times to rule out flakiness"
             );
         }
     }

--- a/src/command/release/git.rs
+++ b/src/command/release/git.rs
@@ -56,7 +56,7 @@ pub(in crate::command::release_impl) fn create_version_tag<'repo>(
                 );
             }
             None => {
-                log::trace!("WOULD create tag {}", tag_name);
+                log::trace!("WOULD create tag {tag_name}");
             }
         }
         Ok(Some(format!("refs/tags/{tag_name}").try_into()?))

--- a/src/command/release/github.rs
+++ b/src/command/release/github.rs
@@ -64,8 +64,7 @@ pub fn create_release(
     cmd.arg(notes);
     if !dry_run && !cmd.status()?.success() {
         log::warn!(
-            "'gh' tool execution failed - considering this non-critical, and you may try to create the release with: {:?}",
-            cmd
+            "'gh' tool execution failed - considering this non-critical, and you may try to create the release with: {cmd:?}"
         );
     }
     Ok(())

--- a/src/command/release/manifest.rs
+++ b/src/command/release/manifest.rs
@@ -246,7 +246,7 @@ fn commit_locks_and_generate_bail_message(
             );
             if !allow_fully_generated_changelogs {
                 for crate_name in crate_names {
-                    log::warn!("{} {}", fix_preamble, crate_name);
+                    log::warn!("{fix_preamble} {crate_name}");
                 }
             }
         }

--- a/src/command/release/mod.rs
+++ b/src/command/release/mod.rs
@@ -269,9 +269,11 @@ fn present_and_validate_dependencies(
                                 causes.iter().map(|n| format!("'{n}'")).collect::<Vec<_>>().join(", ")
                             ))
                             .unwrap_or_default(),
-                        (bump.next_release != bump.desired_release)
-                            .then(|| format!(", ignoring computed version {}", bump.desired_release))
-                            .unwrap_or_default(),
+                        if bump.next_release == bump.desired_release {
+                            "".into()
+                        } else {
+                            format!(", ignoring computed version {}", bump.desired_release)
+                        },
                     );
                 } else if bump.desired_release != dep.package.version {
                     log::info!(

--- a/src/command/release/mod.rs
+++ b/src/command/release/mod.rs
@@ -358,9 +358,11 @@ fn present_and_validate_dependencies(
             .map(|d| d.package.name.as_str())
             .collect::<Vec<_>>();
         if !crate_names_for_manifest_updates.is_empty() {
-            let plural_s = (crate_names_for_manifest_updates.len() > 1)
-                .then_some("s")
-                .unwrap_or_default();
+            let plural_s = if crate_names_for_manifest_updates.len() > 1 {
+                "s"
+            } else {
+                Default::default()
+            };
             log::info!(
                 "{} adjust version constraints in manifest{} of {} package{} as direct dependencies are changing: {}",
                 will(dry_run),
@@ -502,7 +504,7 @@ fn wait_for_release(
         }
 
         std::thread::sleep(sleep_time);
-        log::info!("attempt {}", attempt);
+        log::info!("attempt {attempt}");
     }
     Ok(())
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -84,10 +84,7 @@ fn fill_in_root_crate_if_needed(crate_names: Vec<String>) -> anyhow::Result<Vec<
         } else {
             dir_name.to_owned()
         };
-        log::warn!(
-            "Using '{}' as crate name as no one was provided. Specify one if this isn't correct",
-            crate_name
-        );
+        log::warn!("Using '{crate_name}' as crate name as no one was provided. Specify one if this isn't correct");
         vec![crate_name]
     } else {
         crate_names

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -49,7 +49,7 @@ pub fn change_since_last_release(package: &Package, ctx: &crate::Context) -> any
                         .peel_to_kind(object::Kind::Tree)?
                         .into_tree()
                         .peel_to_entry(components.clone())?
-                        .unwrap_or_else(|| panic!("path '{}' must exist in current_commit `{}`", dir, current_commit))
+                        .unwrap_or_else(|| panic!("path '{dir}' must exist in current_commit `{current_commit}`"))
                         .object_id();
                     if let Some(released_dir_entry) = released_target
                         .object()?


### PR DESCRIPTION
This applies some changes recommended by clippy that have caused the clippy check to start failingo on CI as in:

https://github.com/EliahKagan/cargo-smart-release/actions/runs/16672703924/job/47192391862

This was done by running `cargo clippy --fix` followed by `cargo fmt` and inspecting the result.

---

Based on https://github.com/EliahKagan/cargo-smart-release/pull/24, it looks like the new clippy errors (due to using a newer Rust toolchain) may be all that will need to be fixed for the forthcoming Dependabot grouped version update PR, and that nothing updated in that PR should itself break. But that is not certain, and the PR should be examined once opened.