### PR TITLE
Add support for emoji marked conventional commits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,7 @@ dependencies = [
  "semver",
  "testing_logger",
  "toml_edit 0.23.2",
+ "unicode-properties",
  "winnow",
 ]
 
@@ -2710,6 +2711,12 @@ checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,24 +21,36 @@ path = "src/cli/main-changelog.rs"
 test = false
 [features]
 cache-efficiency-debug = ["gix/cache-efficiency-debug"]
+allow-emoji = ["unicode-properties"]
 
 [dependencies]
-gix = { version = "0.73.0", default-features = false, features = ["max-performance", "interrupt"] }
+gix = { version = "0.73.0", default-features = false, features = [
+    "max-performance",
+    "interrupt",
+] }
 anyhow = "1.0.42"
 clap = { version = "4.5.42", features = ["derive", "cargo"] }
-env_logger = { version = "0.11.6", default-features = false, features = ["humantime", "auto-color"] }
+env_logger = { version = "0.11.6", default-features = false, features = [
+    "humantime",
+    "auto-color",
+] }
 cargo_metadata = "0.21.0"
 log = "0.4.14"
 toml_edit = "0.23.2"
 semver = "1.0.4"
-crates-index = { version = "3.11.0", default-features = false, features = ["git-performance", "git-https"] }
+crates-index = { version = "3.11.0", default-features = false, features = [
+    "git-performance",
+    "git-https",
+] }
 cargo_toml = "0.22.3"
 winnow = "0.7.12"
 git-conventional = "0.12.0"
 jiff = "0.2.15"
 pulldown-cmark = { version = "0.9.6", default-features = false }
 bitflags = "2"
-unicode-properties = { version = "0.1.3", features = ["emoji"], default-features = false }
+unicode-properties = { version = "0.1.3", optional = true, features = [
+    "emoji",
+], default-features = false }
 
 [dev-dependencies]
 insta = "1.43.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ git-conventional = "0.12.0"
 jiff = "0.2.15"
 pulldown-cmark = { version = "0.9.6", default-features = false }
 bitflags = "2"
+unicode-properties = { version = "0.1.3", features = ["emoji"], default-features = false }
 
 [dev-dependencies]
 insta = "1.43.1"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Via `cargo`, which can be obtained using [rustup][rustup]
 cargo install cargo-smart-release
 ```
 
+Install with support for emoji's at the start of commit using `cargo`
+
+```
+cargo install cargo-smart-release --features allow-emoji
+```
+
 ## Features
 
 * [x] safe to use as actually performing an operation requires the `--execute` flag
@@ -63,6 +69,7 @@ cargo install cargo-smart-release
 * [ ] handle version specifications correctly [(tables vs values)](https://github.com/Byron/cargo-release/blob/master/src/cargo.rs#L179:L207)
 * [ ] handle all version comparators correctly (see [here](https://github.com/Byron/cargo-release/blob/master/src/version.rs#L192:L226) for how it's done)
 * [ ] Automatically detect if crate changes are breaking to suggest the correct version increment
+* [x] Support for conventional commits prefixed by an emoji
 
 ## Comparison to `cargo release`
 

--- a/justfile
+++ b/justfile
@@ -32,6 +32,7 @@ doc $RUSTDOCFLAGS="-D warnings":
 # run all unit tests
 unit-tests:
     cargo test --all
+    cargo test --features allow-emoji
 
 cargo-smart-release := `cargo metadata --format-version 1 | jq -r .target_directory` / "debug/cargo-smart-release"
 

--- a/src/command/changelog.rs
+++ b/src/command/changelog.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+
 use crate::{
     bat,
     changelog::write::{Components, Linkables},
@@ -8,7 +10,6 @@ use crate::{
     version::BumpSpec,
     ChangeLog,
 };
-use std::io::Write;
 
 pub fn changelog(opts: Options, crates: Vec<String>) -> anyhow::Result<()> {
     let Options {

--- a/src/command/release/manifest.rs
+++ b/src/command/release/manifest.rs
@@ -5,6 +5,11 @@ use std::{
     str::FromStr,
 };
 
+use anyhow::{bail, Context as ContextTrait};
+use cargo_metadata::{camino::Utf8PathBuf, Package};
+use gix::{lock::File, Id};
+use semver::{Version, VersionReq};
+
 use super::{cargo, git, Context, Options};
 use crate::{
     changelog,
@@ -13,10 +18,6 @@ use crate::{
     utils::{names_and_versions, try_to_published_crate_and_new_version, version_req_unset_or_default, will},
     version, ChangeLog,
 };
-use anyhow::{bail, Context as ContextTrait};
-use cargo_metadata::{camino::Utf8PathBuf, Package};
-use gix::{lock::File, Id};
-use semver::{Version, VersionReq};
 
 pub struct Outcome<'repo, 'meta> {
     pub commit_id: Option<Id<'repo>>,

--- a/src/commit/message.rs
+++ b/src/commit/message.rs
@@ -81,8 +81,10 @@ mod additions {
     }
 }
 
+#[cfg(feature = "allow-emoji")]
 use unicode_properties::{EmojiStatus, UnicodeEmoji};
 
+#[cfg(feature = "allow-emoji")]
 impl From<&'_ str> for Message {
     fn from(m: &str) -> Self {
         let emoji_free = m
@@ -96,6 +98,13 @@ impl From<&'_ str> for Message {
             .collect::<String>();
         let trimmed = emoji_free.trim_start();
         get_message(trimmed)
+    }
+}
+
+#[cfg(not(feature = "allow-emoji"))]
+impl From<&'_ str> for Message {
+    fn from(m: &str) -> Self {
+        get_message(m)
     }
 }
 
@@ -229,6 +238,7 @@ mod tests {
         )
     }
 
+    #[cfg(feature = "allow-emoji")]
     #[test]
     fn conventional_with_scope_and_emoji() {
         assert_eq!(

--- a/src/git/history.rs
+++ b/src/git/history.rs
@@ -4,20 +4,21 @@ use std::{
     iter::FromIterator,
 };
 
+use cargo_metadata::Package;
+use gix::{
+    bstr::ByteSlice,
+    head,
+    prelude::{ObjectIdExt, ReferenceExt},
+    traverse::commit::simple::CommitTimeOrder,
+    Reference,
+};
+
 use crate::{
     commit,
     commit::history::{Item, Segment},
     git::strip_tag_path,
     utils::{component_to_bytes, is_tag_name, is_tag_version, tag_prefix},
     Context,
-};
-use cargo_metadata::Package;
-use gix::traverse::commit::simple::CommitTimeOrder;
-use gix::{
-    bstr::ByteSlice,
-    head,
-    prelude::{ObjectIdExt, ReferenceExt},
-    Reference,
 };
 
 pub enum SegmentScope {


### PR DESCRIPTION
## Introduction
Although emojis are a not part of the conventional commit specification they are frequently used as a visual mark of the type of commit, for example:

> 📝 docs(README): update Rust version badge
> ✨ feat: add error module

## Problem

The commit is not identified as a conventional commit.  

## Solution

These changes provide support for such commits by stripping the emoji and space from the start of the commit text.
- An additional unit test has been added to  account for the case of a commit starting with an emoji icon.
- It is placed behind a feature flag `allow-emoji` to allow users to opt-in should the feature be desired. 
- The unit testing recipe in the just file is updated to run with and without the `allow-emoji` feature enabled.


