### PR TITLE
Don't include `pulldown-cmark` in grouped version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,7 @@ updates:
   groups:
     cargo:
       patterns: ['*']
+      exclude-patterns: ['pulldown-cmark']
 
 - package-ecosystem: github-actions
   directory: '/'


### PR DESCRIPTION
This is an attempt to work around the problem seen in #85 and discussed in comments there, where even though we prohibit version updates to `pulldown-cmark` already (see `dependendabot.yml`, #54, and #59), Dependabot has recently begun to attempt them anyway.

This may not prevent Dependabot from attempting to update the crate to a version it's not supposed to, but it should cause any such attempts to be done in their own PRs, separate from the main grouped PR where other updates are done.

See https://github.com/GitoxideLabs/cargo-smart-release/pull/85#issuecomment-3478160253 for further context. Assuming this works, the Dependabot PR that will be created automatically once this is merged shall supersede #85 and close it automatically; I am deliberately not closing #85 manually because I want to observe if/when that occurs (and because I think closing it manually could lead to greater confusion when examining it later).

---

This is a draft until I fully verify that my other attempts to fix this problem in #85 are not working.