### PR TITLE
fix changelog parsing

### DIFF
--- a/src/changelog/init.rs
+++ b/src/changelog/init.rs
@@ -74,7 +74,10 @@ impl ChangeLog {
             let existing_log = ChangeLog::from_markdown(&markdown);
             let copy_of_existing = existing_log.clone();
             let merged = existing_log
-                .merge_generated(generated)
+                .merge_generated_with_conventional_pruning(
+                    generated,
+                    selection.contains(segment::Selection::GIT_CONVENTIONAL),
+                )
                 .with_context(|| format!("Changelog generation for crate {:?} failed", package.name))?;
             let changed = merged != copy_of_existing;
             (

--- a/src/changelog/merge.rs
+++ b/src/changelog/merge.rs
@@ -92,6 +92,7 @@ impl Section {
                 },
             ) => {
                 assert!(src_unknown.is_empty(), "shouldn't ever generate 'unknown' portions");
+                let expected_conventional_message_ids = expected_conventional_message_ids(&src_segments);
                 let has_no_read_only_segments = !dest_segments.iter().any(Segment::is_read_only);
                 let mode = if has_no_read_only_segments {
                     ReplaceMode::ReplaceAllOrAppend
@@ -122,6 +123,11 @@ impl Section {
                         }
                     }
                 }
+                prune_stale_generated_conventional_messages(
+                    removed_messages,
+                    dest_segments,
+                    &expected_conventional_message_ids,
+                );
                 *dest_date = src_date;
             }
         }
@@ -149,6 +155,63 @@ fn merge_read_only_segment(
     if !found_one && matches!(mode, ReplaceMode::ReplaceAllOrAppend) {
         dest.push(insert);
     }
+}
+
+type ConventionalKey = (&'static str, bool);
+
+fn expected_conventional_message_ids(segments: &[Segment]) -> Vec<(ConventionalKey, Vec<ObjectId>)> {
+    segments
+        .iter()
+        .filter_map(|segment| match segment {
+            Segment::Conventional(section::segment::Conventional {
+                kind,
+                is_breaking,
+                messages,
+                ..
+            }) => Some((
+                (*kind, *is_breaking),
+                messages
+                    .iter()
+                    .filter_map(|message| match message {
+                        conventional::Message::Generated { id, .. } => Some(*id),
+                        conventional::Message::User { .. } => None,
+                    })
+                    .collect(),
+            )),
+            _ => None,
+        })
+        .collect()
+}
+
+fn prune_stale_generated_conventional_messages(
+    removed_in_release: &[ObjectId],
+    dest_segments: &mut Vec<Segment>,
+    expected: &[(ConventionalKey, Vec<ObjectId>)],
+) {
+    dest_segments.retain_mut(|segment| match segment {
+        Segment::Conventional(section::segment::Conventional {
+            kind,
+            is_breaking,
+            removed,
+            messages,
+        }) => {
+            let expected_ids = expected
+                .iter()
+                .find_map(|((expected_kind, expected_is_breaking), ids)| {
+                    (*expected_kind == *kind && *expected_is_breaking == *is_breaking).then_some(ids)
+                });
+            messages.retain(|message| match message {
+                conventional::Message::User { .. } => true,
+                conventional::Message::Generated { id, .. } => {
+                    expected_ids.is_some_and(|ids| ids.contains(id))
+                        && !removed.contains(id)
+                        && !removed_in_release.contains(id)
+                }
+            });
+            !removed.is_empty() || !messages.is_empty()
+        }
+        _ => true,
+    });
 }
 
 fn merge_conventional(

--- a/src/changelog/merge.rs
+++ b/src/changelog/merge.rs
@@ -1,4 +1,7 @@
-use std::{collections::VecDeque, iter::FromIterator};
+use std::{
+    collections::{BTreeSet, VecDeque},
+    iter::FromIterator,
+};
 
 use anyhow::bail;
 use gix::hash::ObjectId;
@@ -15,7 +18,15 @@ use crate::{
 impl ChangeLog {
     /// Bring `generated` into `self` in such a way that `self` preserves everything while enriching itself from `generated`.
     /// Thus we clearly assume that `self` is parsed and `generated` is generated.
-    pub fn merge_generated(mut self, rhs: Self) -> anyhow::Result<Self> {
+    pub fn merge_generated(self, rhs: Self) -> anyhow::Result<Self> {
+        self.merge_generated_with_conventional_pruning(rhs, true)
+    }
+
+    pub fn merge_generated_with_conventional_pruning(
+        mut self,
+        rhs: Self,
+        prune_stale_generated_conventionals: bool,
+    ) -> anyhow::Result<Self> {
         if self.sections.is_empty() {
             return Ok(rhs);
         }
@@ -48,7 +59,8 @@ impl ChangeLog {
                 }
                 Section::Release { ref name, ref date, .. } => {
                     match find_target_section(name, date, sections, first_release_pos) {
-                        Insertion::MergeWith(pos) => sections[pos].merge(section_to_merge)?,
+                        Insertion::MergeWith(pos) => sections[pos]
+                            .merge_with_conventional_pruning(section_to_merge, prune_stale_generated_conventionals)?,
                         Insertion::At(pos) => {
                             if let Section::Release {
                                 heading_level,
@@ -72,6 +84,14 @@ impl ChangeLog {
 
 impl Section {
     pub fn merge(&mut self, src: Section) -> anyhow::Result<()> {
+        self.merge_with_conventional_pruning(src, true)
+    }
+
+    fn merge_with_conventional_pruning(
+        &mut self,
+        src: Section,
+        prune_stale_generated_conventionals: bool,
+    ) -> anyhow::Result<()> {
         let dest = self;
         match (dest, src) {
             (Section::Verbatim { .. }, _) | (_, Section::Verbatim { .. }) => {
@@ -123,11 +143,13 @@ impl Section {
                         }
                     }
                 }
-                prune_stale_generated_conventional_messages(
-                    removed_messages,
-                    dest_segments,
-                    &expected_conventional_message_ids,
-                );
+                if prune_stale_generated_conventionals {
+                    prune_stale_generated_conventional_messages(
+                        removed_messages,
+                        dest_segments,
+                        &expected_conventional_message_ids,
+                    );
+                }
                 *dest_date = src_date;
             }
         }
@@ -159,7 +181,7 @@ fn merge_read_only_segment(
 
 type ConventionalKey = (&'static str, bool);
 
-fn expected_conventional_message_ids(segments: &[Segment]) -> Vec<(ConventionalKey, Vec<ObjectId>)> {
+fn expected_conventional_message_ids(segments: &[Segment]) -> Vec<(ConventionalKey, BTreeSet<ObjectId>)> {
     segments
         .iter()
         .filter_map(|segment| match segment {
@@ -186,7 +208,7 @@ fn expected_conventional_message_ids(segments: &[Segment]) -> Vec<(ConventionalK
 fn prune_stale_generated_conventional_messages(
     removed_in_release: &[ObjectId],
     dest_segments: &mut Vec<Segment>,
-    expected: &[(ConventionalKey, Vec<ObjectId>)],
+    expected: &[(ConventionalKey, BTreeSet<ObjectId>)],
 ) {
     dest_segments.retain_mut(|segment| match segment {
         Segment::Conventional(section::segment::Conventional {

--- a/src/changelog/parse.rs
+++ b/src/changelog/parse.rs
@@ -19,14 +19,15 @@ use crate::{
     changelog,
     changelog::{
         section,
-        section::{
-            segment::{conventional::as_headline, Conventional},
-            Segment,
-        },
+        section::{segment::Conventional, Segment},
         Section,
     },
     ChangeLog,
 };
+
+const CONVENTIONAL_KINDS: &[&str] = &[
+    "fix", "add", "feat", "revert", "remove", "change", "docs", "perf", "chore", "test", "refactor", "other", "style",
+];
 
 impl ChangeLog {
     /// Obtain as much information as possible from `input` and keep everything we didn't understand in respective sections.
@@ -194,19 +195,7 @@ impl Section {
                             segments.push(Segment::Details(section::Data::Parsed));
                             State::SkipGenerated
                         }
-                        Some((Event::Text(title), _range))
-                            if title.starts_with(as_headline("feat").expect("valid"))
-                                || title.starts_with(as_headline("add").expect("valid"))
-                                || title.starts_with(as_headline("revert").expect("valid"))
-                                || title.starts_with(as_headline("remove").expect("valid"))
-                                || title.starts_with(as_headline("change").expect("valid"))
-                                || title.starts_with(as_headline("docs").expect("valid"))
-                                || title.starts_with(as_headline("perf").expect("valid"))
-                                || title.starts_with("refactor")
-                                || title.starts_with("other")
-                                || title.starts_with("style")
-                                || title.starts_with(as_headline("fix").expect("valid")) =>
-                        {
+                        Some((Event::Text(title), _range)) if is_conventional_title(&title) => {
                             State::ParseConventional {
                                 title: title.into_string(),
                             }
@@ -271,19 +260,8 @@ fn parse_conventional_to_next_section_title(
     unknown: &mut String,
 ) -> Segment {
     let is_breaking = title.ends_with(section::segment::Conventional::BREAKING_TITLE_ENCLOSED);
-    let kind = [
-        "fix", "add", "feat", "revert", "remove", "change", "docs", "perf", "refactor", "other", "style",
-    ]
-    .iter()
-    .find(|kind| {
-        let headline = section::segment::conventional::as_headline(kind).unwrap_or(*kind);
-        let common_len = headline.len().min(title.len());
-        title
-            .get(..common_len)
-            .and_then(|t| headline.get(..common_len).map(|h| t.eq_ignore_ascii_case(h)))
-            .unwrap_or(false)
-    })
-    .expect("BUG: this list needs an update too if new kinds of conventional messages are added");
+    let kind = conventional_kind_for_title(&title)
+        .expect("BUG: this list needs an update too if new kinds of conventional messages are added");
 
     let mut conventional = section::segment::Conventional {
         kind,
@@ -362,6 +340,20 @@ fn parse_conventional_to_next_section_title(
         }
     }
     section::Segment::Conventional(conventional)
+}
+
+fn is_conventional_title(title: &str) -> bool {
+    conventional_kind_for_title(title).is_some()
+}
+
+fn conventional_kind_for_title(title: &str) -> Option<&'static str> {
+    CONVENTIONAL_KINDS.iter().copied().find(|kind| {
+        let headline = section::segment::conventional::as_headline(kind).unwrap_or(*kind);
+        title
+            .get(..headline.len())
+            .map(|title_prefix| title_prefix.eq_ignore_ascii_case(headline))
+            .unwrap_or(false)
+    })
 }
 
 fn parse_id_fallback_to_user_message(

--- a/tests/changelog/merge.rs
+++ b/tests/changelog/merge.rs
@@ -414,6 +414,93 @@ fn date_m_d(month: i8, day: i8) -> jiff::Zoned {
 }
 
 #[test]
+fn stale_generated_conventional_messages_are_removed() {
+    let stale_fix_id = hex_to_id("0000000000000000000000000000000000000001");
+    let stale_breaking_id = hex_to_id("0000000000000000000000000000000000000002");
+
+    let parsed = ChangeLog {
+        sections: vec![Section::Release {
+            date: None,
+            name: changelog::Version::Unreleased,
+            heading_level: 2,
+            version_prefix: Section::DEFAULT_PREFIX.into(),
+            removed_messages: vec![],
+            unknown: String::new(),
+            segments: vec![
+                section::Segment::Conventional(section::segment::Conventional {
+                    kind: "fix",
+                    is_breaking: false,
+                    removed: vec![],
+                    messages: vec![
+                        section::segment::conventional::Message::Generated {
+                            id: stale_fix_id,
+                            title: "old generated fix".into(),
+                            body: None,
+                        },
+                        section::segment::conventional::Message::User {
+                            markdown: " - keep this user-authored note".into(),
+                        },
+                    ],
+                }),
+                section::Segment::Conventional(section::segment::Conventional {
+                    kind: "feat",
+                    is_breaking: true,
+                    removed: vec![],
+                    messages: vec![section::segment::conventional::Message::Generated {
+                        id: stale_breaking_id,
+                        title: "old generated breaking feature".into(),
+                        body: None,
+                    }],
+                }),
+            ],
+        }],
+    };
+    let statistics = section::Segment::Statistics(section::Data::Generated(section::segment::CommitStatistics {
+        count: 1,
+        duration: None,
+        time_passed_since_last_release: Some(28),
+        conventional_count: 0,
+        unique_issues: vec![],
+    }));
+    let generated = ChangeLog {
+        sections: vec![Section::Release {
+            date: None,
+            name: changelog::Version::Unreleased,
+            heading_level: 2,
+            version_prefix: Section::DEFAULT_PREFIX.into(),
+            removed_messages: vec![],
+            unknown: String::new(),
+            segments: vec![statistics.clone()],
+        }],
+    };
+
+    let merged = parsed.merge_generated(generated).expect("works");
+
+    assert_eq!(
+        merged.sections,
+        vec![Section::Release {
+            date: None,
+            name: changelog::Version::Unreleased,
+            heading_level: 2,
+            version_prefix: Section::DEFAULT_PREFIX.into(),
+            removed_messages: vec![],
+            unknown: String::new(),
+            segments: vec![
+                section::Segment::Conventional(section::segment::Conventional {
+                    kind: "fix",
+                    is_breaking: false,
+                    removed: vec![],
+                    messages: vec![section::segment::conventional::Message::User {
+                        markdown: " - keep this user-authored note".into(),
+                    }],
+                }),
+                statistics,
+            ],
+        }]
+    );
+}
+
+#[test]
 fn dated_release_insertion_with_undated_sections() {
     // Test that a dated release older than all existing dated releases
     // is inserted before undated sections, not at the end

--- a/tests/changelog/merge.rs
+++ b/tests/changelog/merge.rs
@@ -501,6 +501,78 @@ fn stale_generated_conventional_messages_are_removed() {
 }
 
 #[test]
+fn generated_conventional_messages_survive_when_conventional_generation_is_disabled() {
+    let existing_id = hex_to_id("0000000000000000000000000000000000000001");
+    let parsed = ChangeLog {
+        sections: vec![Section::Release {
+            date: None,
+            name: changelog::Version::Unreleased,
+            heading_level: 2,
+            version_prefix: Section::DEFAULT_PREFIX.into(),
+            removed_messages: vec![],
+            unknown: String::new(),
+            segments: vec![section::Segment::Conventional(section::segment::Conventional {
+                kind: "fix",
+                is_breaking: false,
+                removed: vec![],
+                messages: vec![section::segment::conventional::Message::Generated {
+                    id: existing_id,
+                    title: "existing generated fix".into(),
+                    body: None,
+                }],
+            })],
+        }],
+    };
+    let statistics = section::Segment::Statistics(section::Data::Generated(section::segment::CommitStatistics {
+        count: 1,
+        duration: None,
+        time_passed_since_last_release: Some(28),
+        conventional_count: 0,
+        unique_issues: vec![],
+    }));
+    let generated = ChangeLog {
+        sections: vec![Section::Release {
+            date: None,
+            name: changelog::Version::Unreleased,
+            heading_level: 2,
+            version_prefix: Section::DEFAULT_PREFIX.into(),
+            removed_messages: vec![],
+            unknown: String::new(),
+            segments: vec![statistics.clone()],
+        }],
+    };
+
+    let merged = parsed
+        .merge_generated_with_conventional_pruning(generated, false)
+        .expect("works");
+
+    assert_eq!(
+        merged.sections,
+        vec![Section::Release {
+            date: None,
+            name: changelog::Version::Unreleased,
+            heading_level: 2,
+            version_prefix: Section::DEFAULT_PREFIX.into(),
+            removed_messages: vec![],
+            unknown: String::new(),
+            segments: vec![
+                section::Segment::Conventional(section::segment::Conventional {
+                    kind: "fix",
+                    is_breaking: false,
+                    removed: vec![],
+                    messages: vec![section::segment::conventional::Message::Generated {
+                        id: existing_id,
+                        title: "existing generated fix".into(),
+                        body: None,
+                    }],
+                }),
+                statistics,
+            ],
+        }]
+    );
+}
+
+#[test]
 fn dated_release_insertion_with_undated_sections() {
     // Test that a dated release older than all existing dated releases
     // is inserted before undated sections, not at the end

--- a/tests/changelog/parse.rs
+++ b/tests/changelog/parse.rs
@@ -8,6 +8,8 @@ use cargo_smart_release::{
     ChangeLog,
 };
 
+use crate::changelog::hex_to_id;
+
 #[cfg(not(windows))]
 fn fixup(v: String) -> String {
     v
@@ -148,6 +150,84 @@ fn releases_are_sorted_by_date() {
     assert_eq!(release_versions[2].0, semver::Version::parse("0.75.0").unwrap());
     assert_eq!(release_versions[3].0, semver::Version::parse("0.74.1").unwrap());
     assert_eq!(release_versions[4].0, semver::Version::parse("0.74.0").unwrap());
+}
+
+#[test]
+fn title_case_refactor_breaking_section_parses_as_conventional() {
+    let input = r#"## Unreleased
+
+### Refactor (BREAKING)
+
+ - <csr-id-829393ac596bf2684bd8a837ae931773b24ee033/> ErrorExt::raise_iter to raise_all + remove Frame::downcast
+   Be more compatible to `exn`.
+ - <csr-id-f8517bedcbb9b3328f435aa37f4c63bd30b19fc0/> catch up Exn designs with the upstream
+   refactor!: rename `Exn::from_iter` to `raise_all`
+"#;
+
+    let log = ChangeLog::from_markdown(input);
+
+    let Section::Release { segments, unknown, .. } = &log.sections[0] else {
+        panic!("expected release");
+    };
+    assert!(unknown.is_empty(), "unknown should be empty, got: {unknown:?}");
+    assert_eq!(segments.len(), 1);
+
+    let Segment::Conventional(segment::Conventional {
+        kind,
+        is_breaking,
+        messages,
+        ..
+    }) = &segments[0]
+    else {
+        panic!("expected conventional segment, got {:?}", segments[0]);
+    };
+
+    assert_eq!(*kind, "refactor");
+    assert!(*is_breaking);
+    assert_eq!(messages.len(), 2);
+    assert!(matches!(
+        &messages[0],
+        segment::conventional::Message::Generated {
+            id,
+            title,
+            body: Some(body),
+        } if *id == hex_to_id("829393ac596bf2684bd8a837ae931773b24ee033")
+            && title == "ErrorExt::raise_iter to raise_all + remove Frame::downcast"
+            && body == "Be more compatible to `exn`."
+    ));
+    assert!(matches!(
+        &messages[1],
+        segment::conventional::Message::Generated {
+            id,
+            title,
+            body: Some(body),
+        } if *id == hex_to_id("f8517bedcbb9b3328f435aa37f4c63bd30b19fc0")
+            && title == "catch up Exn designs with the upstream"
+            && body == "refactor!: rename `Exn::from_iter` to `raise_all`"
+    ));
+}
+
+#[test]
+fn partial_conventional_headline_prefix_is_preserved_as_user_markdown() {
+    let input = r#"## Unreleased
+
+### Re
+
+This is a user-authored heading, not a generated refactor section.
+"#;
+
+    let log = ChangeLog::from_markdown(input);
+
+    let Section::Release { segments, unknown, .. } = &log.sections[0] else {
+        panic!("expected release");
+    };
+    assert!(unknown.is_empty(), "unknown should be empty, got: {unknown:?}");
+    assert_eq!(
+        segments,
+        &[Segment::User {
+            markdown: "### Re\n\nThis is a user-authored heading, not a generated refactor section.\n".into()
+        }]
+    );
 }
 
 /// Test for issue #103: Nested unordered list items should not repeat on each release.


### PR DESCRIPTION
### Tasks

* [x] refackiew

----
Fix changelog parsing of title-case conventional sections

Recognize generated conventional changelog headings like `Refactor (BREAKING)` using the same case-insensitive kind matching used when extracting the conventional kind. This prevents generated sections from being parsed back as user markdown and later rejected during merge.
