### PR TITLE
fix: honor --allow-empty-release-message to skip changelog bail in execute mode

### DIFF
--- a/src/command/release/manifest.rs
+++ b/src/command/release/manifest.rs
@@ -85,7 +85,8 @@ pub(in crate::command::release_impl) fn edit_version_and_fixup_dependent_crates_
     }
 
     let would_stop_release = (!changelog_ids_with_statistical_segments_only.is_empty()
-        && !opts.allow_fully_generated_changelogs)
+        && !opts.allow_fully_generated_changelogs
+        && !opts.allow_empty_release_message)
         || (!changelog_ids_probably_lacking_user_edits.is_empty() && !opts.allow_empty_release_message);
     let safety_bumped_packages = crates
         .iter()
@@ -157,7 +158,10 @@ fn commit_locks_and_generate_bail_message(
                 || changelog_ids_with_statistical_segments_only.contains(&idx)
             {
                 lock.commit()?;
-                if !allow_fully_generated_changelogs && !changelog_ids_with_statistical_segments_only.is_empty() {
+                if !allow_fully_generated_changelogs
+                    && !allow_empty_release_message
+                    && !changelog_ids_with_statistical_segments_only.is_empty()
+                {
                     packages_whose_changelogs_need_edits
                         .get_or_insert_with(Vec::new)
                         .push(package);


### PR DESCRIPTION
AI disclosure: This PR was generated with the help of AI

Previously, `--allow-empty-release-message` was only partially honored:
- In dry-run mode, it correctly reported "WOULD continue despite the changelog entry being empty for crate"
- In execute mode (`--execute`), it was ignored for the `changelog_ids_with_statistical_segments_only` check, causing the release to bail with "Write changelog entries for crate(s) ... and try again"

This fixes two locations in `src/command/release/manifest.rs`:

1. `would_stop_release` (line 87-89): Added `&& !opts.allow_empty_release_message` to the first condition so that the commit message correctly reflects whether the release will actually stop.

2. `packages_whose_changelogs_need_edits` population (line 161): Added `!allow_empty_release_message` so that when the flag is set, the execute path skips populating the bail message, allowing the release to proceed (matching what dry-run promises).

The existing `--allow-empty-release-message` CLI flag now fully works as documented: "If changelogs have no message or release information at all, continue anyway."