### PR TITLE
feat: skip yanked versions when determining latest release from crates index

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -134,8 +134,16 @@ pub(crate) fn bump_package_with_spec(
     let desired_release = v;
     let (latest_release, next_release) = match ctx.crates_index.crate_(&package.name) {
         Some(published_crate) => {
-            let latest_release = semver::Version::parse(published_crate.highest_version().version())
-                .expect("valid version in crate index");
+            let latest_release = published_crate
+                .versions()
+                .iter()
+                .filter(|v| !v.is_yanked())
+                .filter_map(|v| semver::Version::parse(v.version()).ok())
+                .max()
+                .unwrap_or_else(|| {
+                    semver::Version::parse(published_crate.highest_version().version())
+                        .expect("valid version in crate index")
+                });
             let next_release = if latest_release >= desired_release {
                 desired_release.clone()
             } else {


### PR DESCRIPTION
AI disclosure: this change was generated with the help of AI, and reviewed by a human

The tool used `highest_version()` which can return yanked versions,
which happened in my repo due to an accidental wrong pre-release publish (oops).

Now iterates all versions, filters out yanked ones, and takes the max.
Falls back to `highest_version()` only if all versions are yanked.

Co-authored-by: Infinity 🤖 <infinity@hydro.run>