### PR TITLE
Revert "feat: skip yanked versions when determining latest release from crates index"

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -134,16 +134,8 @@ pub(crate) fn bump_package_with_spec(
     let desired_release = v;
     let (latest_release, next_release) = match ctx.crates_index.crate_(&package.name) {
         Some(published_crate) => {
-            let latest_release = published_crate
-                .versions()
-                .iter()
-                .filter(|v| !v.is_yanked())
-                .filter_map(|v| semver::Version::parse(v.version()).ok())
-                .max()
-                .unwrap_or_else(|| {
-                    semver::Version::parse(published_crate.highest_version().version())
-                        .expect("valid version in crate index")
-                });
+            let latest_release = semver::Version::parse(published_crate.highest_version().version())
+                .expect("valid version in crate index");
             let next_release = if latest_release >= desired_release {
                 desired_release.clone()
             } else {


### PR DESCRIPTION
Reverts GitoxideLabs/cargo-smart-release#127

I was too fast on this and realize that I don't fully understand the problem to begin with.
https://github.com/GitoxideLabs/cargo-smart-release/pull/127/changes#r3432494456