### PR TITLE
fix: recognize doc as a documentation prefix

### DIFF
--- a/src/commit/message.rs
+++ b/src/commit/message.rs
@@ -143,7 +143,7 @@ fn as_static_str(kind: Option<git_conventional::Type<'_>>) -> Option<&'static st
         "feat" | "add" | "added" => "feat",
         "fix" => "fix",
         "revert" | "remove" => "revert",
-        "docs" => "docs",
+        "doc" | "docs" => "docs",
         "style" => "style",
         "refactor" => "refactor",
         "change" => "change",
@@ -231,6 +231,17 @@ mod tests {
                 additions: vec![]
             }
         )
+    }
+
+    #[test]
+    fn doc_is_a_documentation_alias() {
+        let message = Message::from("doc: clarify release order");
+
+        assert_eq!(message.kind, Some("docs"));
+        assert_eq!(
+            crate::changelog::section::segment::conventional::as_headline(message.kind.expect("conventional kind")),
+            Some("Documentation")
+        );
     }
 
     #[cfg(feature = "allow-emoji")]


### PR DESCRIPTION
## Summary

- Treat `doc:` as an alias for `docs:` when parsing conventional commits.
- Cover both canonical normalization and the resulting `Documentation` changelog heading.

## Why

Gitoxide commonly uses `doc:` commits, but cargo-smart-release currently classifies them under `Other`. Canonicalizing the alias at the commit parser keeps the existing changelog format unchanged. Closes #35.

## Validation

- `cargo test --all`
- `cargo test --features allow-emoji`
- `just journey-tests`
- `cargo clippy --all-targets --all-features -- -D warnings -A clippy::manual_filter`
- `cargo check --all`
- `RUSTDOCFLAGS="-D warnings" cargo doc --all --no-deps`
- `cargo fmt --all -- --check`